### PR TITLE
Multiple code improvements - squid:S1118, common-java:DuplicatedBlocks, squid:S1848, squid:S1213, squid:S1197, squid:S1155, squid:S1488

### DIFF
--- a/src/main/java/com/nadmm/airports/afd/AfdMainActivity.java
+++ b/src/main/java/com/nadmm/airports/afd/AfdMainActivity.java
@@ -64,7 +64,7 @@ public final class AfdMainActivity extends TabPagerActivityBase {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences( this );
         boolean showNearby = prefs.getBoolean( PreferencesActivity.KEY_ALWAYS_SHOW_NEARBY, false );
         ArrayList<String> fav = getDbManager().getAptFavorites();
-        if ( !showNearby && fav.size() > 0 ) {
+        if ( !showNearby && !fav.isEmpty() ) {
             return ID_FAVORITES;
         } else {
             return ID_NEARBY;

--- a/src/main/java/com/nadmm/airports/afd/AirportDetailsFragment.java
+++ b/src/main/java/com/nadmm/airports/afd/AirportDetailsFragment.java
@@ -832,7 +832,7 @@ public final class AirportDetailsFragment extends FragmentBase {
     }
 
     protected void requestMetars( String action, boolean force, boolean cacheOnly ) {
-        if ( mAwosViews.size() == 0 ) {
+        if ( mAwosViews.isEmpty() ) {
             return;
         }
 

--- a/src/main/java/com/nadmm/airports/afd/AirportsCursorHelper.java
+++ b/src/main/java/com/nadmm/airports/afd/AirportsCursorHelper.java
@@ -48,7 +48,9 @@ public class AirportsCursorHelper {
             Airports.REF_LATTITUDE_DEGREES,
             Airports.REF_LONGITUDE_DEGREES,
             States.STATE_NAME
-         };
+    };
+
+    private AirportsCursorHelper() {}
 
     static HashMap<String, String> buildProjectionMap() {
         HashMap<String, String> map = new HashMap<String, String>();
@@ -73,9 +75,8 @@ public class AirportsCursorHelper {
         builder.setTables( Airports.TABLE_NAME+" a LEFT OUTER JOIN "+States.TABLE_NAME+" s"
                 +" ON a."+Airports.ASSOC_STATE+"=s."+States.STATE_CODE );
         builder.setProjectionMap( buildProjectionMap() );
-        Cursor c = builder.query( db, mQueryColumns, selection, selectionArgs,
+        return builder.query( db, mQueryColumns, selection, selectionArgs,
                 groupBy, having, sortOrder, limit );
-        return c;
     }
 
 }

--- a/src/main/java/com/nadmm/airports/afd/CommunicationsFragment.java
+++ b/src/main/java/com/nadmm/airports/afd/CommunicationsFragment.java
@@ -565,7 +565,7 @@ public final class CommunicationsFragment extends FragmentBase {
                 } catch ( Exception e ) {
                     depName = twr1.getString( twr1.getColumnIndex( Tower1.RADIO_CALL_DEP ) );
                 }
-                String depId[] = DataUtils.getAtcFacilityId( depName );
+                String[] depId = DataUtils.getAtcFacilityId( depName );
                 if ( depId == null ) {
                     try {
                         depName = twr1.getString( twr1.getColumnIndex( Tower1.RADIO_CALL_DEP_SECONDARY ) );

--- a/src/main/java/com/nadmm/airports/afd/IlsFragment.java
+++ b/src/main/java/com/nadmm/airports/afd/IlsFragment.java
@@ -101,7 +101,7 @@ public final class IlsFragment extends FragmentBase {
         addRow( layout, "Magnetic bearing", bearing+"\u00B0" );
     }
 
-    protected void showLocalizerDetails( Cursor result[] ) {
+    protected void showLocalizerDetails( Cursor[] result ) {
         Cursor ils2 = result[ 2 ];
         if ( ils2.moveToFirst() ) {
             LinearLayout layout = (LinearLayout) findViewById( R.id.rwy_loc_details );
@@ -124,7 +124,7 @@ public final class IlsFragment extends FragmentBase {
         }
     }
 
-    protected void showGlideslopeDetails( Cursor result[] ) {
+    protected void showGlideslopeDetails( Cursor[] result ) {
         Cursor ils3 = result[ 3 ];
         if ( ils3.moveToFirst() ) {
             LinearLayout layout = (LinearLayout) findViewById( R.id.rwy_gs_details );
@@ -145,7 +145,7 @@ public final class IlsFragment extends FragmentBase {
         }
     }
 
-    protected void showInnerMarkerDetails( Cursor result[] ) {
+    protected void showInnerMarkerDetails( Cursor[] result ) {
         Cursor ils5 = result[ 5 ];
         if ( ils5.moveToFirst() ) {
             LinearLayout layout = (LinearLayout) findViewById( R.id.rwy_im_details );
@@ -164,7 +164,7 @@ public final class IlsFragment extends FragmentBase {
         }
     }
 
-    protected void showMiddleMarkerDetails( Cursor result[] ) {
+    protected void showMiddleMarkerDetails( Cursor[] result ) {
         Cursor ils5 = result[ 6 ];
         if ( ils5.moveToFirst() ) {
             LinearLayout layout = (LinearLayout) findViewById( R.id.rwy_mm_details );
@@ -195,7 +195,7 @@ public final class IlsFragment extends FragmentBase {
         }
     }
 
-    protected void showOuterMarkerDetails( Cursor result[] ) {
+    protected void showOuterMarkerDetails( Cursor[] result ) {
         Cursor ils5 = result[ 7 ];
         if ( ils5.moveToFirst() ) {
             LinearLayout layout = (LinearLayout) findViewById( R.id.rwy_om_details );
@@ -226,7 +226,7 @@ public final class IlsFragment extends FragmentBase {
         }
     }
 
-    protected void showIlsRemarks( Cursor result[] ) {
+    protected void showIlsRemarks( Cursor[] result ) {
         Cursor ils6 = result[ 8 ];
         LinearLayout layout = (LinearLayout) findViewById( R.id.rwy_ils_remarks );
         if ( ils6.moveToFirst() ) {

--- a/src/main/java/com/nadmm/airports/billing/utils/Base64DecoderException.java
+++ b/src/main/java/com/nadmm/airports/billing/utils/Base64DecoderException.java
@@ -20,6 +20,8 @@ package com.nadmm.airports.billing.utils;
  * @author nelson
  */
 public class Base64DecoderException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     public Base64DecoderException() {
         super();
     }
@@ -27,6 +29,4 @@ public class Base64DecoderException extends Exception {
     public Base64DecoderException(String s) {
         super(s);
     }
-
-    private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/com/nadmm/airports/billing/utils/IabHelper.java
+++ b/src/main/java/com/nadmm/airports/billing/utils/IabHelper.java
@@ -149,6 +149,11 @@ public class IabHelper {
     public static final String GET_SKU_DETAILS_ITEM_LIST = "ITEM_ID_LIST";
     public static final String GET_SKU_DETAILS_ITEM_TYPE_LIST = "ITEM_TYPE_LIST";
 
+
+    // The listener registered on launchPurchaseFlow, which we have to call back when
+    // the purchase finishes
+    OnIabPurchaseFinishedListener mPurchaseListener;
+
     /**
      * Creates an instance. After creation, it will not yet be ready to use. You must perform
      * setup by calling {@link #startSetup} and wait for setup to complete. This constructor does not
@@ -324,10 +329,6 @@ public class IabHelper {
          */
         void onIabPurchaseFinished(IabResult result, Purchase info);
     }
-
-    // The listener registered on launchPurchaseFlow, which we have to call back when
-    // the purchase finishes
-    OnIabPurchaseFinishedListener mPurchaseListener;
 
     public void launchPurchaseFlow(Activity act, String sku, int requestCode, OnIabPurchaseFinishedListener listener) {
         launchPurchaseFlow(act, sku, requestCode, listener, "");
@@ -906,7 +907,7 @@ public class IabHelper {
             }
         }
 
-        if (skuList.size() == 0) {
+        if (skuList.isEmpty()) {
             logDebug("queryPrices: nothing to do because there are no SKUs.");
             return BILLING_RESPONSE_RESULT_OK;
         }

--- a/src/main/java/com/nadmm/airports/billing/utils/Security.java
+++ b/src/main/java/com/nadmm/airports/billing/utils/Security.java
@@ -43,6 +43,8 @@ public class Security {
     private static final String KEY_FACTORY_ALGORITHM = "RSA";
     private static final String SIGNATURE_ALGORITHM = "SHA1withRSA";
 
+    private Security() {}
+
     /**
      * Verifies that the data was signed with the given signature, and returns
      * the verified purchase. The data is in JSON format and signed

--- a/src/main/java/com/nadmm/airports/data/DatabaseManager.java
+++ b/src/main/java/com/nadmm/airports/data/DatabaseManager.java
@@ -53,12 +53,21 @@ public class DatabaseManager {
     private static final Object sLock = new Object();
     private static DatabaseManager sInstance = null;
 
+    private DatabaseManager( Context context ) {
+        mContext = context;
+        mCatalogDbHelper = new CatalogDbOpenHelper( context );
+        mUserDataDbHelper = new UserDataDbOpenHelper( context );
+        mDatabases = new HashMap<>();
+    }
+
     public static final class LocationColumns {
         public static final String LOCATION = "LOCATION";
         public static final String DISTANCE = "DISTANCE";
         public static final String BEARING = "BEARING";
         public static final String RADIUS = "RADIUS";
         public static final String RADIAL = "RADIAL";
+
+        private LocationColumns() {}
     }
 
     public static final class Airports implements BaseColumns {
@@ -144,6 +153,8 @@ public class DatabaseManager {
         public static final String WIND_INDICATOR = "WIND_INDICATOR";
         public static final String ICAO_CODE = "ICAO_CODE";
         public static final String TIMEZONE_ID = "TIMEZONE_ID";
+
+        private Airports() {}
     }
 
     public static final class Runways implements BaseColumns {
@@ -221,6 +232,8 @@ public class DatabaseManager {
         public static final String RECIPROCAL_END_LDA = "RECIPROCAL_END_LDA";
         public static final String RECIPROCAL_END_LAHSO_DISTANCE = "RECIPROCAL_END_LAHSO_DISTANCE";
         public static final String RECIPROCAL_END_LAHSO_RUNWAY = "RECIPROCAL_END_LAHSO_RUNWAY";
+
+        private Runways() {}
     }
 
     public static final class Ars implements BaseColumns {
@@ -229,6 +242,8 @@ public class DatabaseManager {
         public static final String RUNWAY_ID = "RUNWAY_ID";
         public static final String RUNWAY_END_ID = "RUNWAY_END_ID";
         public static final String ARRESTING_DEVICE = "ARRESTING_DEVICE";
+
+        private Ars() {}
     }
 
     public static final class Remarks implements BaseColumns {
@@ -236,6 +251,8 @@ public class DatabaseManager {
         public static final String SITE_NUMBER = "SITE_NUMBER";
         public static final String REMARK_NAME = "REMARK_NAME";
         public static final String REMARK_TEXT = "REMARK_TEXT";
+
+        private Remarks() {}
     }
 
     public static final class Attendance implements BaseColumns {
@@ -243,6 +260,8 @@ public class DatabaseManager {
         public static final String SITE_NUMBER = "SITE_NUMBER";
         public static final String SEQUENCE_NUMBER = "SEQUENCE_NUMBER";
         public static final String ATTENDANCE_SCHEDULE = "ATTENDANCE_SCHEDULE";
+
+        private Attendance() {}
     }
 
     public static final class Tower1 implements BaseColumns {
@@ -257,6 +276,8 @@ public class DatabaseManager {
         public static final String RADIO_CALL_DEP_PRIMARY = "RADIO_CALL_DEP_PRIMARY";
         public static final String RADIO_CALL_APCH_SECONDARY = "RADIO_CALL_APCH_SECONDARY";
         public static final String RADIO_CALL_DEP_SECONDARY = "RADIO_CALL_DEP_SECONDARY";
+
+        private Tower1() {}
     }
 
     public static final class Tower2 implements BaseColumns {
@@ -267,6 +288,8 @@ public class DatabaseManager {
         public static final String PRIMARY_DEPARTURE_HOURS = "PRIMARY_DEPARTURE_HOURS";
         public static final String SECONDARY_DEPARTURE_HOURS = "SECONDARY_DEPARTURE_HOURS";
         public static final String CONTROL_TOWER_HOURS = "CONTROL_TOWER_HOURS";
+
+        private Tower2() {}
     }
 
     public static final class Tower3 implements BaseColumns {
@@ -274,12 +297,16 @@ public class DatabaseManager {
         public static final String FACILITY_ID = "FACILITY_ID";
         public static final String MASTER_AIRPORT_FREQ = "MASTER_AIRPORT_FREQ";
         public static final String MASTER_AIRPORT_FREQ_USE = "MASTER_AIRPORT_FREQ_USE";
+
+        private Tower3() {}
     }
 
     public static final class Tower4 implements BaseColumns {
         public static final String TABLE_NAME = "tower4";
         public static final String FACILITY_ID = "FACILITY_ID";
         public static final String MASTER_AIRPORT_SERVICES = "MASTER_AIRPORT_SERVICES";
+
+        private Tower4() {}
     }
 
     public static final class Tower6 implements BaseColumns {
@@ -287,6 +314,8 @@ public class DatabaseManager {
         public static final String FACILITY_ID = "FACILITY_ID";
         public static final String ELEMENT_NUMBER = "ELEMENT_NUMBER";
         public static final String REMARK_TEXT = "REMARK_TEXT";
+
+        private Tower6() {}
     }
 
     public static final class Tower7 implements BaseColumns {
@@ -295,6 +324,8 @@ public class DatabaseManager {
         public static final String SATELLITE_AIRPORT_SITE_NUMBER = "SATELLITE_AIRPORT_SITE_NUMBER";
         public static final String MASTER_AIRPORT_SITE_NUMBER = "MASTER_AIRPORT_SITE_NUMBER";
         public static final String SATELLITE_AIRPORT_FREQ = "SATELLITE_AIRPORT_FREQ";
+
+        private Tower7() {}
     }
 
     public static final class Tower8 implements BaseColumns {
@@ -302,6 +333,8 @@ public class DatabaseManager {
         public static final String FACILITY_ID = "FACILITY_ID";
         public static final String AIRSPACE_TYPES = "AIRSPACE_TYPES";
         public static final String AIRSPACE_HOURS = "AIRSPACE_HOURS";
+
+        private Tower8() {}
     }
 
     public static final class Tower9 implements BaseColumns {
@@ -311,6 +344,8 @@ public class DatabaseManager {
         public static final String ATIS_HOURS = "ATIS_HOURS";
         public static final String ATIS_PURPOSE = "ATIS_PURPOSE";
         public static final String ATIS_PHONE = "ATIS_PHONE";
+
+        private Tower9() {}
     }
 
     public static final class Awos1 implements BaseColumns {
@@ -324,6 +359,8 @@ public class DatabaseManager {
         public static final String SECOND_STATION_FREQUENCY = "SECOND_STATION_FREQUENCY";
         public static final String STATION_PHONE_NUMBER = "STATION_PHONE_NUMBER";
         public static final String SITE_NUMBER = "SITE_NUMBER";
+
+        private Awos1() {}
     }
 
 
@@ -332,6 +369,8 @@ public class DatabaseManager {
         public static final String WX_SENSOR_IDENT = "WX_SENSOR_IDENT";
         public static final String WX_SENSOR_TYPE = "WX_SENSOR_TYPE";
         public static final String WX_STATION_REMARKS = "WX_STATION_REMARKS";
+
+        private Awos2() {}
     }
 
     public static final class Nav1 implements BaseColumns {
@@ -357,6 +396,8 @@ public class DatabaseManager {
         public static final String NAVAID_FREQUENCY = "NAVAID_FREQUENCY";
         public static final String FANMARKER_TYPE = "FANMARKER_TYPE";
         public static final String PROTECTED_FREQUENCY_ALTITUDE = "PROTECTED_FREQUENCY_ALTITUDE";
+
+        private Nav1() {}
     }
 
     public static final class Nav2 implements BaseColumns {
@@ -364,6 +405,8 @@ public class DatabaseManager {
         public static final String NAVAID_ID = "NAVAID_ID";
         public static final String NAVAID_TYPE = "NAVAID_TYPE";
         public static final String REMARK_TEXT = "REMARK_TEXT";
+
+        private Nav2() {}
     }
 
     public static final class Ils1 implements BaseColumns {
@@ -374,6 +417,8 @@ public class DatabaseManager {
         public static final String ILS_ID = "ILS_ID";
         public static final String ILS_CATEGORY = "ILS_CATEGORY";
         public static final String ILS_MAGNETIC_BEARING = "ILS_MAGNETIC_BEARING";
+
+        private Ils1() {}
     }
 
     public static final class Ils2 implements BaseColumns {
@@ -386,6 +431,8 @@ public class DatabaseManager {
         public static final String LOCALIZER_FREQUENCY = "LOCALIZER_FREQUENCY";
         public static final String LOCALIZER_BACK_COURSE_STATUS = "LOCALIZER_BACK_COURSE_STATUS";
         public static final String LOCALIZER_COURSE_WIDTH = "LOCALIZER_COURSE_WIDTH";
+
+        private Ils2() {}
     }
 
     public static final class Ils3 implements BaseColumns {
@@ -398,6 +445,8 @@ public class DatabaseManager {
         public static final String GLIDE_SLOPE_TYPE = "GLIDE_SLOPE_TYPE";
         public static final String GLIDE_SLOPE_ANGLE = "GLIDE_SLOPE_ANGLE";
         public static final String GLIDE_SLOPE_FREQUENCY = "GLIDE_SLOPE_FREQUENCY";
+
+        private Ils3() {}
     }
 
     public static final class Ils4 implements BaseColumns {
@@ -408,6 +457,8 @@ public class DatabaseManager {
         public static final String OPERATIONAL_STATUS = "OPERATIONAL_STATUS";
         public static final String OPERATIONAL_EFFECTIVE_DATE = "OPERATIONAL_EFFECTIVE_DATE";
         public static final String DME_CHANNEL = "DME_CHANNEL";
+
+        private Ils4() {}
     }
 
     public static final class Ils5 implements BaseColumns {
@@ -428,6 +479,8 @@ public class DatabaseManager {
         public static final String MARKER_BEACON_FREQUENCY = "MARKER_BEACON_FREQUENCY";
         public static final String MARKER_NAVAID_ID = "MARKER_NAVAID_ID";
         public static final String MARKER_SERVICE = "MARKER_SERVICE";
+
+        private Ils5() {}
     }
 
     public static final class Ils6 implements BaseColumns {
@@ -436,6 +489,8 @@ public class DatabaseManager {
         public static final String RUNWAY_ID = "RUNWAY_ID";
         public static final String ILS_TYPE = "ILS_TYPE";
         public static final String ILS_REMARKS = "ILS_REMARKS";
+
+        private Ils6() {}
     }
 
     public static final class Aff1 implements BaseColumns {
@@ -446,6 +501,8 @@ public class DatabaseManager {
         public static final String FACILITY_TYPE = "FACILITY_TYPE";
         public static final String ARTCC_LATTITUDE_DEGREES = "ARTCC_LATTITUDE_DEGREES";
         public static final String ARTCC_LONGITUDE_DEGREES = "ARTCC_LONGITUDE_DEGREES";
+
+        private Aff1() {}
     }
 
     public static final class Aff3 implements BaseColumns {
@@ -457,6 +514,8 @@ public class DatabaseManager {
         public static final String FREQ_ALTITUDE = "FREQ_ALTITUDE";
         public static final String FREQ_USAGE_NAME= "FREQ_USAGE_NAME";
         public static final String IFR_FACILITY_ID = "IFR_FACILITY_ID";
+
+        private Aff3() {}
     }
 
     public static final class Com implements BaseColumns {
@@ -470,6 +529,8 @@ public class DatabaseManager {
         public static final String COMM_OUTLET_FREQS = "COMM_OUTLET_FREQS";
         public static final String FSS_IDENT = "FSS_IDENT";
         public static final String FSS_NAME = "FSS_NAME";
+
+        private Com() {}
     }
 
     public static final class Wxs implements BaseColumns {
@@ -483,6 +544,8 @@ public class DatabaseManager {
         public static final String STATION_COUNTRY = "STATION_COUNTRY";
         public static final String STATION_ELEVATOIN_METER = "STATION_ELEVATION_METER";
         public static final String STATION_SITE_TYPES = "STATION_SITE_TYPES";
+
+        private Wxs() {}
     }
 
     public static final class AtcPhones implements BaseColumns {
@@ -492,6 +555,8 @@ public class DatabaseManager {
         public static final String DUTY_OFFICE_PHONE = "DUTY_OFFICE_PHONE";
         public static final String BUSINESS_HOURS = "BUSINESS_HOURS";
         public static final String BUSINESS_PHONE = "BUSINESS_PHONE";
+
+        private AtcPhones() {}
     }
 
     public static final class DtppCycle implements BaseColumns {
@@ -499,6 +564,8 @@ public class DatabaseManager {
         public static final String TPP_CYCLE = "TPP_CYCLE";
         public static final String FROM_DATE = "FROM_DATE";
         public static final String TO_DATE = "TO_DATE";
+
+        private DtppCycle() {}
     }
 
     public static final class Dtpp implements BaseColumns {
@@ -513,6 +580,8 @@ public class DatabaseManager {
         public static final String FAANFD18_CODE = "FAANFD18_CODE";
         public static final String MILITARY_USE = "MILITARY_USE";
         public static final String COPTER_USE = "COPTER_USE";
+
+        private Dtpp() {}
     }
 
     public static final class DafdCycle implements BaseColumns {
@@ -520,18 +589,24 @@ public class DatabaseManager {
         public static final String AFD_CYCLE = "AFD_CYCLE";
         public static final String FROM_DATE = "FROM_DATE";
         public static final String TO_DATE = "TO_DATE";
+
+        private DafdCycle() {}
     }
 
     public static final class Dafd implements BaseColumns {
         public static final String TABLE_NAME = "dafd";
         public static final String FAA_CODE = "FAA_CODE";
         public static final String PDF_NAME = "PDF_NAME";
+
+        private Dafd() {}
     }
 
     public static final class BookCategories implements BaseColumns {
         public static final String TABLE_NAME = "bookcategories";
         public static final String CATEGORY_CODE = "CATEGORY_CODE";
         public static final String CATEGORY_NAME = "CATEGORY_NAME";
+
+        private BookCategories() {}
     }
 
     public static final class Library implements BaseColumns {
@@ -543,6 +618,8 @@ public class DatabaseManager {
         public static final String EDITION = "EDITION";
         public static final String DOWNLOAD_SIZE = "DOWNLOAD_SIZE";
         public static final String FLAG = "FLAG";
+
+        private Library() {}
     }
 
     public static final class Catalog implements BaseColumns {
@@ -554,18 +631,24 @@ public class DatabaseManager {
         public static final String END_DATE = "END_DATE";
         public static final String DB_NAME = "DB_NAME";
         public static final String INSTALL_DATE = "INSTALL_DATE";
+
+        private Catalog() {}
     }
 
     public static final class States implements BaseColumns {
         public static final String TABLE_NAME = "states";
         public static final String STATE_CODE = "STATE_CODE";
         public static final String STATE_NAME = "STATE_NAME";
+
+        private States() {}
     }
 
     public static final class Favorites implements BaseColumns {
         public static final String TABLE_NAME = "favorites";
         public static final String TYPE = "TYPE";
         public static final String LOCATION_ID = "LOCATION_ID";
+
+        private Favorites() {}
     }
 
     public static DatabaseManager instance( Context context ) {
@@ -575,13 +658,6 @@ public class DatabaseManager {
             }
             return sInstance;
         }
-    }
-
-    private DatabaseManager( Context context ) {
-        mContext = context;
-        mCatalogDbHelper = new CatalogDbOpenHelper( context );
-        mUserDataDbHelper = new UserDataDbOpenHelper( context );
-        mDatabases = new HashMap<>();
     }
 
     public File getDatabaseFile( String dbName ) {

--- a/src/main/java/com/nadmm/airports/donate/DonateDatabase.java
+++ b/src/main/java/com/nadmm/airports/donate/DonateDatabase.java
@@ -55,6 +55,8 @@ public class DonateDatabase {
         public static final String TABLE_NAME = "donations";
         public static final String PRODUCT_ID = "PRODUCT_ID";
         public static final String PURCHASE_TIME = "PURCHASE_TIME";
+
+        private Donations() {}
     }
 
     public  void deleteAllDonations() {

--- a/src/main/java/com/nadmm/airports/notams/NotamFragmentBase.java
+++ b/src/main/java/com/nadmm/airports/notams/NotamFragmentBase.java
@@ -147,7 +147,7 @@ public class NotamFragmentBase extends FragmentBase {
             in = new BufferedReader( new FileReader( notamFile ) );
             String notam;
             while ( ( notam = in.readLine() ) != null ) {
-                String parts[] = notam.split( " ", 5 );
+                String[] parts = notam.split( " ", 5 );
                 String notamID = parts[ 1 ];
                 if ( !notamIDs.contains( notamID ) ) {
                     String keyword = parts[0].equals( "!FDC" )? "FDC" : parts[ 3 ];

--- a/src/main/java/com/nadmm/airports/tfr/TfrList.java
+++ b/src/main/java/com/nadmm/airports/tfr/TfrList.java
@@ -33,6 +33,10 @@ public class TfrList implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    public boolean isValid;
+    public long fetchTime;
+    public ArrayList<Tfr> entries;
+
     public enum AltitudeType {
         AGL {
             @Override
@@ -161,9 +165,5 @@ public class TfrList implements Serializable {
         fetchTime = Long.MAX_VALUE;
         entries = new ArrayList<Tfr>();
     }
-
-    public boolean isValid;
-    public long fetchTime;
-    public ArrayList<Tfr> entries;
 
 }

--- a/src/main/java/com/nadmm/airports/utils/ClassBUtils.java
+++ b/src/main/java/com/nadmm/airports/utils/ClassBUtils.java
@@ -29,6 +29,8 @@ public class ClassBUtils {
     static private HashMap<String, String> mClassBFileNames = new HashMap<>();
     static private String mClassBFacilityList = new String();
 
+    private ClassBUtils() {}
+
     static {
         mClassBNames.put( "ATL", "Atlanta" );
         mClassBNames.put( "BOS", "Boston" );

--- a/src/main/java/com/nadmm/airports/utils/DataUtils.java
+++ b/src/main/java/com/nadmm/airports/utils/DataUtils.java
@@ -29,6 +29,12 @@ public final class DataUtils {
     private final static String DOT = "\u2022";
     private final static String DASH = "\u2013";
     private static HashMap<String, String> sMorseCodes = new HashMap<>();
+
+    private static final Map<String, String> sAtcIdToName = new HashMap<>();
+    private static final Map<String, String> sAtcNameToId = new HashMap<>();
+
+    private DataUtils() {}
+
     static {
         sMorseCodes.put( "A", DOT+DASH );
         sMorseCodes.put( "B", DASH+DOT+DOT+DOT );
@@ -835,9 +841,6 @@ public final class DataUtils {
             return "Other";
         }
     }
-
-    private static final Map<String, String> sAtcIdToName = new HashMap<>();
-    private static final Map<String, String> sAtcNameToId = new HashMap<>();
 
     static {
         sAtcIdToName.put( "A11:TRACON", "Anchorage" );

--- a/src/main/java/com/nadmm/airports/utils/FileUtils.java
+++ b/src/main/java/com/nadmm/airports/utils/FileUtils.java
@@ -29,6 +29,8 @@ import java.io.Reader;
 @SuppressWarnings( "TryFinallyCanBeTryWithResources" )
 public class FileUtils {
 
+    private FileUtils() {}
+
     public static void removeDir( File dir ) {
         File[] files = dir.listFiles();
         if ( files != null ) {

--- a/src/main/java/com/nadmm/airports/utils/FormatUtils.java
+++ b/src/main/java/com/nadmm/airports/utils/FormatUtils.java
@@ -36,6 +36,8 @@ public class FormatUtils {
     private final static DecimalFormat sNMFormat;
     private final static NumberFormat sDollarFormat;
 
+    private FormatUtils() {}
+
     static {
         sFeetFormat = new DecimalFormat();
         sFeetFormat.applyPattern( "#,##0.# ft" );

--- a/src/main/java/com/nadmm/airports/utils/GeoUtils.java
+++ b/src/main/java/com/nadmm/airports/utils/GeoUtils.java
@@ -42,6 +42,8 @@ public class GeoUtils {
 
     private static final int TWO_MINUTES = 1000 * 60 * 2;
 
+    private GeoUtils() {}
+
     public static double getEarthRadius( double radLat ) {
         // Earth radius in nautical miles at a given lattitude, according to the WGS-84 ellipsoid
         // http://en.wikipedia.org/wiki/Earth_radius
@@ -82,7 +84,7 @@ public class GeoUtils {
     }
 
     public static double[] getBoundingBoxDegrees( Location location, int r ) {
-        double box[] = getBoundingBoxRadians( location, r );
+        double[] box = getBoundingBoxRadians( location, r );
         box[ 0 ] = Math.toDegrees( box[ 0 ] );
         box[ 1 ] = Math.toDegrees( box[ 1 ] );
         box[ 2 ] = Math.toDegrees( box[ 2 ] );

--- a/src/main/java/com/nadmm/airports/utils/NetworkUtils.java
+++ b/src/main/java/com/nadmm/airports/utils/NetworkUtils.java
@@ -54,6 +54,8 @@ public class NetworkUtils {
     public static final String CONTENT_LENGTH = "CONTENT_LENGTH";
     public static final String CONTENT_NAME = "CONTENT_NAME";
 
+    private NetworkUtils() {}
+
     public static boolean isNetworkAvailable( Context context ) {
         return isNetworkAvailable( context, true );
     }

--- a/src/main/java/com/nadmm/airports/utils/SolarCalculator.java
+++ b/src/main/java/com/nadmm/airports/utils/SolarCalculator.java
@@ -172,8 +172,7 @@ public class SolarCalculator {
     }
 
     private double getUtcTime( double localMeanTime ) {
-        double utcTime = localMeanTime-getBaseLongitudeHour();
-        return utcTime;
+        return localMeanTime-getBaseLongitudeHour();
     }
 
     private double getLocalTime( double localMeanTime, Calendar date ) {

--- a/src/main/java/com/nadmm/airports/utils/SystemUtils.java
+++ b/src/main/java/com/nadmm/airports/utils/SystemUtils.java
@@ -34,6 +34,8 @@ public class SystemUtils {
 
     private final static String MIME_TYPE_PDF = "application/pdf";
 
+    private SystemUtils() {}
+
     public static boolean canDisplayMimeType( Context context, String mimeType ) {
         PackageManager pm = context.getPackageManager();
         Intent intent = new Intent( Intent.ACTION_VIEW );

--- a/src/main/java/com/nadmm/airports/utils/TimeUtils.java
+++ b/src/main/java/com/nadmm/airports/utils/TimeUtils.java
@@ -45,6 +45,8 @@ public class TimeUtils {
     private static final SimpleDateFormat FAA_FORMAT =
             new SimpleDateFormat( "MM/dd/yyyy", Locale.US );
 
+    private TimeUtils() {}
+
     public static CharSequence formatLongDateTime( long time ) {
         return DateFormat.format( "MMM dd, yyyy h:mmaa", new Date( time ) );
     }

--- a/src/main/java/com/nadmm/airports/utils/UiUtils.java
+++ b/src/main/java/com/nadmm/airports/utils/UiUtils.java
@@ -46,8 +46,12 @@ public class UiUtils {
 
     private static final LruCache<String, Drawable> sDrawableCache = new LruCache<>( 100 );
 
-    private final static Handler sHandler;
-    private final static Paint sPaint = new Paint( Paint.FILTER_BITMAP_FLAG );
+    private static final  Handler sHandler;
+    private static final  Paint sPaint = new Paint( Paint.FILTER_BITMAP_FLAG );
+
+    private static final int[] RES_IDS_ACTION_BAR_SIZE = { R.attr.actionBarSize };
+
+    private UiUtils() {}
 
     static {
         // Make sure to associate with the Looper in the main (Gui) thread
@@ -228,8 +232,6 @@ public class UiUtils {
         tv.setCompoundDrawablesWithIntrinsicBounds( d, null, null, null );
         tv.setCompoundDrawablePadding( UiUtils.convertDpToPx( context, 5 ) );
     }
-
-    private static final int[] RES_IDS_ACTION_BAR_SIZE = { R.attr.actionBarSize };
 
     /** Calculates the Action Bar height in pixels. */
     public static int calculateActionBarSize( Context context ) {

--- a/src/main/java/com/nadmm/airports/views/DrawShadowFrameLayout.java
+++ b/src/main/java/com/nadmm/airports/views/DrawShadowFrameLayout.java
@@ -39,6 +39,20 @@ public class DrawShadowFrameLayout extends FrameLayout {
     private ObjectAnimator mAnimator;
     private float mAlpha = 1f;
 
+    private static Property<DrawShadowFrameLayout, Float> SHADOW_ALPHA
+            = new Property<DrawShadowFrameLayout, Float>(Float.class, "shadowAlpha") {
+        @Override
+        public Float get(DrawShadowFrameLayout dsfl) {
+            return dsfl.mAlpha;
+        }
+
+        @Override
+        public void set(DrawShadowFrameLayout dsfl, Float value) {
+            dsfl.mAlpha = value;
+            ViewCompat.postInvalidateOnAnimation( dsfl );
+        }
+    };
+
     public DrawShadowFrameLayout( Context context ) {
         this(context, null, 0);
     }
@@ -116,17 +130,4 @@ public class DrawShadowFrameLayout extends FrameLayout {
         setWillNotDraw(!mShadowVisible || mShadowDrawable == null);
     }
 
-    private static Property<DrawShadowFrameLayout, Float> SHADOW_ALPHA
-            = new Property<DrawShadowFrameLayout, Float>(Float.class, "shadowAlpha") {
-        @Override
-        public Float get(DrawShadowFrameLayout dsfl) {
-            return dsfl.mAlpha;
-        }
-
-        @Override
-        public void set(DrawShadowFrameLayout dsfl, Float value) {
-            dsfl.mAlpha = value;
-            ViewCompat.postInvalidateOnAnimation( dsfl );
-        }
-    };
 }

--- a/src/main/java/com/nadmm/airports/views/ImageZoomView.java
+++ b/src/main/java/com/nadmm/airports/views/ImageZoomView.java
@@ -769,6 +769,29 @@ public class ImageZoomView extends View implements Observer {
         /** Handler for posting runnables */
         private final Handler mHandler = new Handler();
 
+        /**
+         * Runnable that updates dynamics state
+         */
+        private final Runnable mUpdateRunnable = new Runnable() {
+            public void run() {
+                final long startTime = SystemClock.uptimeMillis();
+                mPanDynamicsX.update(startTime);
+                mPanDynamicsY.update(startTime);
+                final boolean isAtRest = mPanDynamicsX.isAtRest(REST_VELOCITY_TOLERANCE,
+                        REST_POSITION_TOLERANCE)
+                        && mPanDynamicsY.isAtRest(REST_VELOCITY_TOLERANCE, REST_POSITION_TOLERANCE);
+                mState.setPanX(mPanDynamicsX.getPosition());
+                mState.setPanY(mPanDynamicsY.getPosition());
+
+                if (!isAtRest) {
+                    final long stopTime = SystemClock.uptimeMillis();
+                    mHandler.postDelayed(mUpdateRunnable, 1000 / FPS - (stopTime - startTime));
+                }
+
+                mState.notifyObservers();
+            }
+        };
+
         /** Creates new zoom control */
         public DynamicZoomControl() {
             mPanDynamicsX.setFriction(3f);
@@ -855,29 +878,6 @@ public class ImageZoomView extends View implements Observer {
 
             mState.notifyObservers();
         }
-
-        /**
-         * Runnable that updates dynamics state
-         */
-        private final Runnable mUpdateRunnable = new Runnable() {
-            public void run() {
-                final long startTime = SystemClock.uptimeMillis();
-                mPanDynamicsX.update(startTime);
-                mPanDynamicsY.update(startTime);
-                final boolean isAtRest = mPanDynamicsX.isAtRest(REST_VELOCITY_TOLERANCE,
-                        REST_POSITION_TOLERANCE)
-                        && mPanDynamicsY.isAtRest(REST_VELOCITY_TOLERANCE, REST_POSITION_TOLERANCE);
-                mState.setPanX(mPanDynamicsX.getPosition());
-                mState.setPanY(mPanDynamicsY.getPosition());
-
-                if (!isAtRest) {
-                    final long stopTime = SystemClock.uptimeMillis();
-                    mHandler.postDelayed(mUpdateRunnable, 1000 / FPS - (stopTime - startTime));
-                }
-
-                mState.notifyObservers();
-            }
-        };
 
         /**
          * Release control and start pan fling animation

--- a/src/main/java/com/nadmm/airports/wx/AirSigmet.java
+++ b/src/main/java/com/nadmm/airports/wx/AirSigmet.java
@@ -26,6 +26,10 @@ public class AirSigmet implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    public boolean isValid;
+    public long fetchTime;
+    public ArrayList<AirSigmetEntry> entries;
+
     public static class AirSigmetPoint implements Serializable {
 
         private static final long serialVersionUID = 1L;
@@ -70,9 +74,5 @@ public class AirSigmet implements Serializable {
         fetchTime = Long.MAX_VALUE;
         entries = new ArrayList<>();
     }
-
-    public boolean isValid;
-    public long fetchTime;
-    public ArrayList<AirSigmetEntry> entries;
 
 }

--- a/src/main/java/com/nadmm/airports/wx/WxCursorHelper.java
+++ b/src/main/java/com/nadmm/airports/wx/WxCursorHelper.java
@@ -47,6 +47,8 @@ public class WxCursorHelper {
             Airports.ASSOC_STATE,
     };
 
+    private WxCursorHelper() {}
+
     public static Cursor query( SQLiteDatabase db, String selection, String[] selectionArgs,
             String groupBy, String having, String sortOrder, String limit ) {
         SQLiteQueryBuilder builder = new SQLiteQueryBuilder();

--- a/src/main/java/com/nadmm/airports/wx/WxRegions.java
+++ b/src/main/java/com/nadmm/airports/wx/WxRegions.java
@@ -66,4 +66,5 @@ public class WxRegions {
         "Winnemucca, NV"
     };
 
+    private WxRegions() {}
 }

--- a/src/main/java/com/nadmm/airports/wx/WxSymbol.java
+++ b/src/main/java/com/nadmm/airports/wx/WxSymbol.java
@@ -30,9 +30,15 @@ import com.nadmm.airports.R;
 public abstract class WxSymbol implements Serializable, Cloneable {
 
     private static final long serialVersionUID = 1L;
+    public static final String MINUS_SIGN = "-";
+    public static final String PLUS_SIGN = "+";
 
     private static Map<String, WxSymbol> sWxSymbolsMap = new HashMap<String, WxSymbol>();
     private static ArrayList<String> sSymbols = new ArrayList<String>();
+
+
+    protected String mIntensity;
+    protected String mSymbol;
 
     private WxSymbol() {}
 
@@ -52,9 +58,9 @@ public abstract class WxSymbol implements Serializable, Cloneable {
     public String toString() {
         String desc = getDescription();
         if ( mIntensity.length() > 0 ) {
-            if ( mIntensity.equals( "+" ) ) {
+            if ( mIntensity.equals(PLUS_SIGN) ) {
                 desc = "Heavy "+desc.toLowerCase( Locale.US );
-            } else if ( mIntensity.equals( "-" ) ) {
+            } else if ( mIntensity.equals(MINUS_SIGN) ) {
                 desc = "Light "+desc.toLowerCase( Locale.US );
             }
         }
@@ -87,648 +93,84 @@ public abstract class WxSymbol implements Serializable, Cloneable {
     abstract public int getDrawable();
     abstract protected String getDescription();
 
-    protected String mIntensity;
-    protected String mSymbol;
-
     static {
-        new WxSymbol( "BCFG" ) {
+        createWxSymbol("BCFG", R.drawable.bcfg, "Patches of fog");
 
-            private static final long serialVersionUID = 1L;
+        createWxSymbol("PRFG", R.drawable.prfg, "Partial fog");
 
-            @Override
-            public int getDrawable() {
-                return R.drawable.bcfg;
-            }
+        createWxSymbol("MIFG", R.drawable.mifg, "Shallow fog");
 
-            @Override
-            protected String getDescription() {
-                return "Patches of fog";
-            }
-        };
+        createWxSymbol("BLDU", R.drawable.sa, "Blowing dust");
 
-        new WxSymbol( "PRFG" ) {
+        createWxSymbol("BLSA", R.drawable.sa, "Blowing sand");
 
-            private static final long serialVersionUID = 1L;
+        createWxSymbol("BLSN", R.drawable.blsn, "Blowing snow");
 
-            @Override
-            public int getDrawable() {
-                return R.drawable.prfg;
-            }
+        createWxSymbol("BLPY", R.drawable.sa, "Blowing spray");
 
-            @Override
-            protected String getDescription() {
-                return "Partial fog";
-            }
-        };
+        createWxSymbol("VCBR", R.drawable.vcbr, "Mist in the vicinity");
 
-        new WxSymbol( "MIFG" ) {
+        createWxSymbol("TSGS", R.drawable.h_tsgr, R.drawable.tsgr, "Thunderstorm with small hail", PLUS_SIGN);
 
-            private static final long serialVersionUID = 1L;
+        createWxSymbol("TSGR", R.drawable.h_tsgr, R.drawable.tsgr, "Thunderstorm with hail", PLUS_SIGN);
 
-            @Override
-            public int getDrawable() {
-                return R.drawable.mifg;
-            }
+        createWxSymbol("VCTS", R.drawable.vcts, "Thunderstorm in the vicinity");
 
-            @Override
-            protected String getDescription() {
-                return "Shallow fog";
-            }
-        };
+        createWxSymbol("DRDU", R.drawable.ss, "Low drifting dust");
 
-        new WxSymbol( "BLDU" ) {
+        createWxSymbol("DRSA", R.drawable.ss, "Low drifting sand");
 
-            private static final long serialVersionUID = 1L;
+        createWxSymbol("DRSN", R.drawable.drsn, "Low drifting snow");
 
-            @Override
-            public int getDrawable() {
-                return R.drawable.sa;
-            }
+        createWxSymbol("FZFG", R.drawable.fzfg, "Freezing fog");
 
-            @Override
-            protected String getDescription() {
-                return "Blowing dust";
-            }
-        };
+        createWxSymbol("FZDZ", R.drawable.l_fzdz, R.drawable.fzdz, "Freezing drizzle", MINUS_SIGN);
 
-        new WxSymbol( "BLSA" ) {
+        createWxSymbol("FZRA", R.drawable.l_fzra, R.drawable.fzra, "Freezing rain", MINUS_SIGN);
 
-            private static final long serialVersionUID = 1L;
+        createWxSymbol("SHRA", R.drawable.l_sh, R.drawable.sh, "Rainshowers", MINUS_SIGN);
 
-            @Override
-            public int getDrawable() {
-                return R.drawable.sa;
-            }
+        createWxSymbol("SHSN", R.drawable.l_shsn, R.drawable.shsn, "Snowshowers", MINUS_SIGN);
 
-            @Override
-            protected String getDescription() {
-                return "Blowing sand";
-            }
-        };
+        createWxSymbol("SHPL", R.drawable.pl, "Ice pellet showers");
 
-        new WxSymbol( "BLSN" ) {
+        createWxSymbol("SHGS", R.drawable.l_gs, R.drawable.gs, "Small hail showers", MINUS_SIGN);
 
-            private static final long serialVersionUID = 1L;
+        createWxSymbol("SHGR", R.drawable.l_gr, R.drawable.gr, "Hail showers", MINUS_SIGN);
 
-            @Override
-            public int getDrawable() {
-                return R.drawable.blsn;
-            }
+        createWxSymbol("VCFG", R.drawable.vcfg, "Fog in the vicinity");
 
-            @Override
-            protected String getDescription() {
-                return "Blowing snow";
-            }
-        };
+        createWxSymbol("VCFC", R.drawable.fc, "Funel clouds in the vicinity");
 
-        new WxSymbol( "BLPY" ) {
+        createWxSymbol("VCSS", R.drawable.vcss, "Sandstorm in the vicinity");
 
-            private static final long serialVersionUID = 1L;
+        createWxSymbol("VCDS", R.drawable.vcss, "Duststorm in the vicinity");
 
-            @Override
-            public int getDrawable() {
-                return R.drawable.sa;
-            }
+        createWxSymbol("VCSH", R.drawable.vcsh, "Showers in the vicinity");
 
-            @Override
-            protected String getDescription() {
-                return "Blowing spray";
-            }
-        };
-
-        new WxSymbol( "VCBR" ) {
-
-            private static final long serialVersionUID = 1L;
+        createWxSymbol("VCPO", R.drawable.po, "Dust/sand whirls in the vicinity");
 
-            @Override
-            public int getDrawable() {
-                return R.drawable.vcbr;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Mist in the vicinity";
-            }
-        };
-
-        new WxSymbol( "TSGS" ) {
-
-            private static final long serialVersionUID = 1L;
+        createWxSymbol("VCBLDU", R.drawable.sa, "Blowing dust in the vicinity");
 
-            @Override
-            public int getDrawable() {
-                if (mIntensity.equals( "+" ) ) {
-                    return R.drawable.h_tsgr;
-                } else {
-                    return R.drawable.tsgr;
-                }
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Thunderstorm with small hail";
-            }
-        };
+        createWxSymbol("VCBLSA", R.drawable.sa, "Blowing sand in the vicinity");
 
-        new WxSymbol( "TSGR" ) {
+        createWxSymbol("VCBLSN", R.drawable.blsn, "Blowing snow in the vicinity");
 
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                if (mIntensity.equals( "+" ) ) {
-                    return R.drawable.h_tsgr;
-                } else {
-                    return R.drawable.tsgr;
-                }
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Thunderstorm with hail";
-            }
-        };
-
-        new WxSymbol( "VCTS" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.vcts;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Thunderstorm in the vicinity";
-            }
-        };
-
-        new WxSymbol( "DRDU" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.ss;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Low drifting dust";
-            }
-        };
-
-        new WxSymbol( "DRSA" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.ss;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Low drifting sand";
-            }
-        };
-
-        new WxSymbol( "DRSN" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.drsn;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Low drifting snow";
-            }
-        };
-
-        new WxSymbol( "FZFG" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.fzfg;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Freezing fog";
-            }
-        };
-
-        new WxSymbol( "FZDZ" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                if ( mIntensity.equals( "-" ) ) {
-                    return R.drawable.l_fzdz;
-                } else {
-                    return R.drawable.fzdz;
-                }
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Freezing drizzle";
-            }
-        };
-
-        new WxSymbol( "FZRA" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                if ( mIntensity.equals( "-" ) ) {
-                    return R.drawable.l_fzra;
-                } else {
-                    return R.drawable.fzra;
-                }
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Freezing rain";
-            }
-        };
-
-        new WxSymbol( "SHRA" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                if ( mIntensity.equals( "-" ) ) {
-                    return R.drawable.l_sh;
-                } else {
-                    return R.drawable.sh;
-                }
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Rainshowers";
-            }
-        };
-
-        new WxSymbol( "SHSN" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                if ( mIntensity.equals( "-" ) ) {
-                    return R.drawable.l_shsn;
-                } else {
-                    return R.drawable.shsn;
-                }
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Snowshowers";
-            }
-        };
-
-        new WxSymbol( "SHPL" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.pl;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Ice pellet showers";
-            }
-        };
-
-        new WxSymbol( "SHGS" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                if ( mIntensity.equals( "-" ) ) {
-                    return R.drawable.l_gs;
-                } else {
-                    return R.drawable.gs;
-                }
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Small hail showers";
-            }
-        };
-
-        new WxSymbol( "SHGR" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                if ( mIntensity.equals( "-" ) ) {
-                    return R.drawable.l_gr;
-                } else {
-                    return R.drawable.gr;
-                }
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Hail showers";
-            }
-        };
-
-        new WxSymbol( "VCFG" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.vcfg;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Fog in the vicinity";
-            }
-        };
-
-        new WxSymbol( "VCFC" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.fc;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Funel clouds in the vicinity";
-            }
-        };
-
-        new WxSymbol( "VCSS" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.vcss;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Sandstorm in the vicinity";
-            }
-        };
-
-        new WxSymbol( "VCDS" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.vcss;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Duststorm in the vicinity";
-            }
-        };
-
-        new WxSymbol( "VCSH" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.vcsh;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Showers in the vicinity";
-            }
-        };
-
-        new WxSymbol( "VCPO" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.po;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Dust/sand whirls in the vicinity";
-            }
-        };
-
-        new WxSymbol( "VCBLDU" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.sa;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Blowing dust in the vicinity";
-            }
-        };
-
-        new WxSymbol( "VCBLSA" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.sa;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Blowing sand in the vicinity";
-            }
-        };
-
-        new WxSymbol( "VCBLSN" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.blsn;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Blowing snow in the vicinity";
-            }
-        };
-
-        new WxSymbol( "TSRA" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                if ( mIntensity.equals( "+" ) ) {
-                    return R.drawable.h_tsra;
-                } else {
-                    return R.drawable.tsra;
-                }
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Thunderstorm with rain";
-            }
-        };
-
-        new WxSymbol( "TSPL" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                if ( mIntensity.equals( "+" ) ) {
-                    return R.drawable.h_tsra;
-                } else {
-                    return R.drawable.tsra;
-                }
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Thunderstorm with ice pellets";
-            }
-        };
-
-        new WxSymbol( "TSSN" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                if ( mIntensity.equals( "+" ) ) {
-                    return R.drawable.h_tsra;
-                } else {
-                    return R.drawable.tsra;
-                }
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Thunderstorm with snow";
-            }
-        };
-
-        new WxSymbol( "BR" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.br;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Mist";
-            }
-        };
-
-        new WxSymbol( "DU" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.du;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Widespread dust";
-            }
-        };
-
-        new WxSymbol( "DZ" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                if ( mIntensity.equals( "+" ) ) {
-                    return R.drawable.h_dz;
-                } else if ( mIntensity.equals( "-" ) ) {
-                    return R.drawable.l_dz;
-                } else {
-                    return R.drawable.dz;
-                }
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Drizzle";
-            }
-        };
-
-        new WxSymbol( "DS" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                if ( mIntensity.equals( "+" ) ) {
-                    return R.drawable.h_ss;
-                } else {
-                    return R.drawable.ss;
-                }
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Duststorm";
-            }
-        };
-
-        new WxSymbol( "FG" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.fg;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Fog";
-            }
-        };
+        createWxSymbol("TSRA", R.drawable.h_tsra, R.drawable.tsra, "Thunderstorm with rain", PLUS_SIGN);
+
+        createWxSymbol("TSPL", R.drawable.h_tsra, R.drawable.tsra, "Thunderstorm with ice pellets", PLUS_SIGN);
+
+        createWxSymbol("TSSN", R.drawable.h_tsra, R.drawable.tsra, "Thunderstorm with snow", PLUS_SIGN);
+
+        createWxSymbol("BR", R.drawable.br, "Mist");
+
+        createWxSymbol("DU", R.drawable.du, "Widespread dust");
+
+        createWxSymbol("DZ", R.drawable.h_dz, R.drawable.l_dz, R.drawable.dz, "Drizzle");
+
+        createWxSymbol("DS", R.drawable.h_ss, R.drawable.ss, "Duststorm", PLUS_SIGN);
+
+        createWxSymbol("FG", R.drawable.fg, "Fog");
 
         new WxSymbol( "FC" ) {
 
@@ -747,7 +189,7 @@ public abstract class WxSymbol implements Serializable, Cloneable {
             @Override
             public String toString() {
                 String desc;
-                if ( mIntensity.equals( "+" ) ) {
+                if ( mIntensity.equals(PLUS_SIGN) ) {
                     desc = "Tornado";
                 } else {
                     desc = "Funnel clouds";
@@ -756,301 +198,100 @@ public abstract class WxSymbol implements Serializable, Cloneable {
             }
         };
 
-        new WxSymbol( "FU" ) {
+        createWxSymbol("FU", R.drawable.fu, "Smoke");
+
+        createWxSymbol("GS", R.drawable.l_gs, R.drawable.gs, "Small hail", MINUS_SIGN);
+
+        createWxSymbol("GR", R.drawable.l_gr, R.drawable.gr, "Hail", MINUS_SIGN);
+
+        createWxSymbol("HZ", R.drawable.hz, "Haze");
+
+        createWxSymbol("IC", R.drawable.ic, "Ice crystals");
+
+        createWxSymbol("UP", R.drawable.up, "Unknown precipitation");
+
+        createWxSymbol("PL", R.drawable.pl, "Ice pellets");
+
+        createWxSymbol("PO", R.drawable.po, "Dust/sand whirls");
+
+        createWxSymbol("RA", R.drawable.h_ra, R.drawable.l_ra, R.drawable.ra, "Rain");
+
+        createWxSymbol("SN", R.drawable.h_sn, R.drawable.l_sn, R.drawable.sn, "Snow");
+
+        createWxSymbol("SG", R.drawable.sg, "Snow grains");
+
+        createWxSymbol("SQ", R.drawable.sq, "Squalls");
+
+        createWxSymbol("SA", R.drawable.sa, "Sand");
+
+        createWxSymbol("SS", R.drawable.h_ss, R.drawable.ss, "Sandstorm", PLUS_SIGN);
+
+        createWxSymbol("SH", R.drawable.l_sh, R.drawable.sh, "Showers", MINUS_SIGN);
+
+        createWxSymbol("TS", R.drawable.ts, "Thunderstorm");
+
+        createWxSymbol("VA", R.drawable.fu, "Volcanic ash");
+
+        createWxSymbol("NSW", 0, "No significant weather");
+    }
+
+    private static void createWxSymbol(String code, final int drawable, final String description) {
+        new WxSymbol(code) {
 
             private static final long serialVersionUID = 1L;
 
             @Override
             public int getDrawable() {
-                return R.drawable.fu;
+                return drawable;
             }
 
             @Override
             protected String getDescription() {
-                return "Smoke";
+                return description;
             }
         };
+    }
 
-        new WxSymbol( "GS" ) {
+    private static void createWxSymbol(String code, final int drawable1, final int drawable2, final String description, final String sign) {
+        new WxSymbol(code) {
 
             private static final long serialVersionUID = 1L;
 
             @Override
             public int getDrawable() {
-                if ( mIntensity.equals( "-" ) ) {
-                    return R.drawable.l_gs;
+                if (mIntensity.equals(sign) ) {
+                    return drawable1;
                 } else {
-                    return R.drawable.gs;
+                    return drawable2;
                 }
             }
 
             @Override
             protected String getDescription() {
-                return "Small hail";
+                return description;
             }
         };
+    }
 
-        new WxSymbol( "GR" ) {
+    private static void createWxSymbol(String code, final int drawable1, final int drawable2, final int drawable3, final String description) {
+        new WxSymbol(code) {
 
             private static final long serialVersionUID = 1L;
 
             @Override
             public int getDrawable() {
-                if ( mIntensity.equals( "-" ) ) {
-                    return R.drawable.l_gr;
+                if ( mIntensity.equals(PLUS_SIGN) ) {
+                    return drawable1;
+                } else if ( mIntensity.equals(MINUS_SIGN) ) {
+                    return drawable2;
                 } else {
-                    return R.drawable.gr;
+                    return drawable3;
                 }
             }
 
             @Override
             protected String getDescription() {
-                return "Hail";
-            }
-        };
-
-        new WxSymbol( "HZ" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.hz;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Haze";
-            }
-        };
-
-        new WxSymbol( "IC" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.ic;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Ice crystals";
-            }
-        };
-
-        new WxSymbol( "UP" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.up;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Unknown precipitation";
-            }
-        };
-
-        new WxSymbol( "PL" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.pl;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Ice pellets";
-            }
-        };
-
-        new WxSymbol( "PO" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.po;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Dust/sand whirls";
-            }
-        };
-
-        new WxSymbol( "RA" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                if ( mIntensity.equals( "+" ) ) {
-                    return R.drawable.h_ra;
-                } else if ( mIntensity.equals( "-" ) ) {
-                    return R.drawable.l_ra;
-                } else {
-                    return R.drawable.ra;
-                }
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Rain";
-            }
-        };
-
-        new WxSymbol( "SN" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                if ( mIntensity.equals( "+" ) ) {
-                    return R.drawable.h_sn;
-                } else if ( mIntensity.equals( "-" ) ) {
-                    return R.drawable.l_sn;
-                } else {
-                    return R.drawable.sn;
-                }
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Snow";
-            }
-        };
-
-        new WxSymbol( "SG" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.sg;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Snow grains";
-            }
-        };
-
-        new WxSymbol( "SQ" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.sq;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Squalls";
-            }
-        };
-
-        new WxSymbol( "SA" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.sa;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Sand";
-            }
-        };
-
-        new WxSymbol( "SS" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                if ( mIntensity.equals( "+" ) ) {
-                    return R.drawable.h_ss;
-                } else {
-                    return R.drawable.ss;
-                }
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Sandstorm";
-            }
-        };
-
-        new WxSymbol( "SH" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                if ( mIntensity.equals( "-" ) ) {
-                    return R.drawable.l_sh;
-                } else {
-                    return R.drawable.sh;
-                }
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Showers";
-            }
-        };
-
-        new WxSymbol( "TS" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.ts;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Thunderstorm";
-            }
-        };
-
-        new WxSymbol( "VA" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return R.drawable.fu;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "Volcanic ash";
-            }
-        };
-
-        new WxSymbol( "NSW" ) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int getDrawable() {
-                return 0;
-            }
-
-            @Override
-            protected String getDescription() {
-                return "No significant weather";
+                return description;
             }
         };
     }

--- a/src/main/java/com/nadmm/airports/wx/WxUtils.java
+++ b/src/main/java/com/nadmm/airports/wx/WxUtils.java
@@ -37,6 +37,8 @@ public class WxUtils {
     private static final String CATEGORY_IFR = "IFR";
     private static final String CATEGORY_LIFR = "LIFR";
 
+    private WxUtils() {}
+
     static public int getFlightCategoryColor( String flightCategory ) {
         int color = 0;
         if ( flightCategory.equals( CATEGORY_VFR ) ) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
common-java:DuplicatedBlocks - Source files should not have any duplicated blocks.
squid:S1848 - Objects should not be created to be dropped immediately without being used.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/common-java:DuplicatedBlocks
https://dev.eclipse.org/sonar/rules/show/squid:S1848
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S1488
Please let me know if you have any questions.
George Kankava